### PR TITLE
Bugfix for crash when only home_assistant_devices_file is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ Since HA does not cope well with bluetooth device tracking (https://home-assista
 
 ## Installation
 
+For raspbian install required packages:
 
-$ `gem install home_assistant-ble`
+    $ sudo apt-get install ruby-dev libcap-dev
+
+    $ gem install home_assistant-ble
 
 ## Usage
 

--- a/lib/home_assistant/ble.rb
+++ b/lib/home_assistant/ble.rb
@@ -56,6 +56,8 @@ module HomeAssistant
             devices[mac] = Mash.new( name: name )
           end
         end
+
+        return devices
       end
 
       def run


### PR DESCRIPTION
When only home_assistant_devices_file is defined without any home_assistant_devices defined, or the whole section is omitted this causes a crash.

Also adds instructions on the necessary packages for raspbian