### PR TITLE
Daemonize

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,19 @@ For raspbian install required packages:
 
 ## Usage
 
-Run `home_assistant-ble [your config file]` binary.
+Run `home_assistant-ble -c [your config file]` binary.
+
+The following command line options are recognized
+
+    -c CONFIG_FILE  - location of the config file
+    -v              - verbose
+    -f              - run in foreground
+    -p PID_FILE     - where to write the PID file
 
 ### Systemd
 
-To launch as a systemd service, you can copy `home_assistant-ble.service` file present in this repo.
+To launch as a systemd service, you can copy `home_assistant-ble.service` file present in this repo. 
+If you want to run the service using a different user/group you need to make sure that the PID file can be written to /run. By default the run directory is writable only by root, so you will need to write the PID at a different location.
 
 I'll probably build an archlinux package at some point (TODO).
 

--- a/bin/home_assistant-ble
+++ b/bin/home_assistant-ble
@@ -11,9 +11,19 @@ require 'byebug'
 $stdout.sync = true
 $stderr.sync = true
 
+@options = {
+  pid_file: "/run/home_assistant-ble.pid",
+  verbose: false
+}
+config = {}
+
 def shut_down
   @detector.clean_all_devices
   $stdout.puts 'Quitting...'
+
+  if @options[:pid_file]
+    File.unlink(@options[:pid_file])
+  end
 end
 
 Signal.trap('INT') do
@@ -28,35 +38,41 @@ Signal.trap('TERM') do
   exit
 end
 
-options = {}
-config = {}
-
 OptionParser.new do |opts|
-  opts.banner = "Usage: example.rb [options]"
+  opts.banner = "Usage: home_assistant-ble [options]"
 
   opts.on('-v', '--[no-]verbose', 'Run verbosely') do |v|
-    options[:verbose] = v
+    @options[:verbose] = v
   end
 
   opts.on('-c CONFIG_FILE', '--config CONFIG_FILE', 'Specify config file') do |config_file|
-    options[:config_file] = config_file
+    @options[:config_file] = config_file
   end
 
   opts.on('-f', 'Run in foreground') do |run_in_foreground|
-    options[:run_in_foreground] = run_in_foreground
+    @options[:run_in_foreground] = run_in_foreground
+  end
+
+  opts.on('-p PID_FILE', '--[no-]pid-file PID_FILE', 'PID file location') do |pid_file|
+    @options[:pid_file] = pid_file
   end
 end.parse!
 
-if options[:config_file]
-  config = YAML.load_file(options[:config_file])
+if @options[:config_file]
+  config = YAML.load_file(@options[:config_file])
 else
   $stderr.puts 'No configuration file specified, will use all default values'
 end
 
-if not options[:run_in_foreground]
-  Process.daemon(true)
+unless @options[:run_in_foreground]
+  Process.daemon(true, @options[:verbose])
+
+  if @options[:pid_file]
+    File.open(@options[:pid_file], 'w') { |f| f.write Process.pid }
+    $stdout.puts "Writing pid to #{@options[:pid_file]}" if @options[:verbose]  
+  end
 else
-  $stdout.puts "Continuing in foreground" if options[:verbose]
+  $stdout.puts 'Continuing in foreground' if @options[:verbose]
 end
 
 @detector = HomeAssistant::Ble::Detector.new(config)

--- a/bin/home_assistant-ble
+++ b/bin/home_assistant-ble
@@ -12,7 +12,7 @@ $stdout.sync = true
 $stderr.sync = true
 
 @options = {
-  pid_file: "/run/home_assistant-ble.pid",
+  pid_file: '/run/home_assistant-ble.pid',
   verbose: false
 }
 config = {}
@@ -21,9 +21,7 @@ def shut_down
   @detector.clean_all_devices
   $stdout.puts 'Quitting...'
 
-  if @options[:pid_file] && !@options[:run_in_foreground]
-    File.unlink(@options[:pid_file])
-  end
+  File.unlink(@options[:pid_file]) if @options[:pid_file] && !@options[:run_in_foreground]
 end
 
 Signal.trap('INT') do
@@ -39,7 +37,7 @@ Signal.trap('TERM') do
 end
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: home_assistant-ble [options]"
+  opts.banner = 'Usage: home_assistant-ble [options]'
 
   opts.on('-v', '--[no-]verbose', 'Run verbosely') do |v|
     @options[:verbose] = v
@@ -64,15 +62,15 @@ else
   $stderr.puts 'No configuration file specified, will use all default values'
 end
 
-unless @options[:run_in_foreground]
+if @options[:run_in_foreground]
+  $stdout.puts 'Continuing in foreground' if @options[:verbose]
+else
   Process.daemon(true, @options[:verbose])
 
   if @options[:pid_file]
     File.open(@options[:pid_file], 'w') { |f| f.write Process.pid }
-    $stdout.puts "Writing pid to #{@options[:pid_file]}" if @options[:verbose]  
+    $stdout.puts "Writing pid to #{@options[:pid_file]}" if @options[:verbose]
   end
-else
-  $stdout.puts 'Continuing in foreground' if @options[:verbose]
 end
 
 @detector = HomeAssistant::Ble::Detector.new(config)

--- a/bin/home_assistant-ble
+++ b/bin/home_assistant-ble
@@ -2,6 +2,8 @@
 
 require 'home_assistant/ble'
 require 'yaml'
+require 'optparse'
+require 'byebug'
 
 # force stdout/stderr to flush immediately
 # this will allow to follow logs when launched via systemd
@@ -26,12 +28,35 @@ Signal.trap('TERM') do
   exit
 end
 
-config_file = ARGV.shift
+options = {}
 config = {}
-if config_file
-  config = YAML.load_file(config_file)
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: example.rb [options]"
+
+  opts.on('-v', '--[no-]verbose', 'Run verbosely') do |v|
+    options[:verbose] = v
+  end
+
+  opts.on('-c CONFIG_FILE', '--config CONFIG_FILE', 'Specify config file') do |config_file|
+    options[:config_file] = config_file
+  end
+
+  opts.on('-f', 'Run in foreground') do |run_in_foreground|
+    options[:run_in_foreground] = run_in_foreground
+  end
+end.parse!
+
+if options[:config_file]
+  config = YAML.load_file(options[:config_file])
 else
   $stderr.puts 'No configuration file specified, will use all default values'
+end
+
+if not options[:run_in_foreground]
+  Process.daemon(true)
+else
+  $stdout.puts "Continuing in foreground" if options[:verbose]
 end
 
 @detector = HomeAssistant::Ble::Detector.new(config)

--- a/bin/home_assistant-ble
+++ b/bin/home_assistant-ble
@@ -21,7 +21,7 @@ def shut_down
   @detector.clean_all_devices
   $stdout.puts 'Quitting...'
 
-  if @options[:pid_file]
+  if @options[:pid_file] && !@options[:run_in_foreground]
     File.unlink(@options[:pid_file])
   end
 end

--- a/home_assistant-ble.service
+++ b/home_assistant-ble.service
@@ -7,7 +7,9 @@ After=network.target
 #Group=hass
 
 Environment=RUBYOPT="-w0"
-ExecStart=/usr/bin/home_assistant-ble /var/lib/hass/ble.yml
+Type=forking
+ExecStart=/usr/bin/home_assistant-ble -c /var/lib/hass/ble.yml
+PIDFile=/run/home_assistant-ble.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes the script into a proper daemon, that by default forks and runs in the background.

I've also added handling for command line options. A peculiarity is that if you run the systemd script and you want to see the debug log you should change the ExecStart line to include the `-v` (verbose) option