### PR TITLE
issue #3: disable http compression to work around ruby Net::HTTP issues.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ Metrics/LineLength:
   Max: 140
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 35
 
 Metrics/ClassLength:
   Max: 200

--- a/lib/home_assistant/ble.rb
+++ b/lib/home_assistant/ble.rb
@@ -120,6 +120,7 @@ module HomeAssistant
         uri = URI.join(home_assistant_url, '/api/services/device_tracker/see')
         request = Net::HTTP::Post.new(uri)
         request.content_type = 'application/json'
+        request['Accept-Encoding'] = 'identity'
         request['X-Ha-Access'] = home_assistant_password if home_assistant_password
         request.body = ha_conf.to_json
         req_options = { use_ssl: uri.scheme == 'https' }


### PR DESCRIPTION
I'm running this on a RaspberryPI 3B with ruby 2.3.0. I had the same or similar issue; crash when receiving the response from homeassistant. BTW, I'm running HA 0.85.1 on a RaspberryPI 3B. I suspected an issue with deflating the response from HA, so I forced the accept-encoding header to 'identity' to disable compressed responses. That fixed the issue and it's now working. I do not believe that home_assistant_ble will every be transferring huge amounts of data, so this is probably an acceptable change - until ruby is fixed. 
